### PR TITLE
fix: plugin readiness audit remediation (F-01 through F-05)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ dist/
 node_modules/
 *.tgz
 gr-file-manifest.json
+mlflow.db
+video_analysis/

--- a/bin/lib/config.js
+++ b/bin/lib/config.js
@@ -23,7 +23,7 @@ const MCP_SERVERS = {
   },
   playwright: {
     command: 'npx',
-    args: ['@playwright/mcp@latest', '--headless', '--caps=vision,pdf'],
+    args: ['@playwright/mcp@0.0.68', '--headless', '--caps=vision,pdf'],
   },
   'mlflow-mcp': {
     command: 'uvx',

--- a/commands/explain-video.md
+++ b/commands/explain-video.md
@@ -23,9 +23,9 @@ Based on input type:
 
 **YouTube URL**: Call `video_analyze(url, instruction="Extract key concepts, structure, and talking points for creating an educational explainer video")`
 
-**Webpage URL**: Call `content_analyze(source=url, instruction="Extract main topics, key facts, and narrative structure")`
+**Webpage URL**: Call `content_analyze(url=url, instruction="Extract main topics, key facts, and narrative structure")`
 
-**Topic text**: Call `research_deep(topic, scope="moderate", instruction="Research this topic for an educational explainer video. Focus on: key concepts, common misconceptions, real-world examples, and logical narrative flow")`
+**Topic text**: Call `research_deep(topic="<topic text — include research context for an educational explainer video. Focus on: key concepts, common misconceptions, real-world examples, and logical narrative flow>", scope="moderate")`
 
 ## Phase 2: Content Preparation
 

--- a/docs/PLUGIN_DISTRIBUTION.md
+++ b/docs/PLUGIN_DISTRIBUTION.md
@@ -17,15 +17,15 @@ The npm package contains zero Python code. The PyPI package contains zero JavaSc
 
 ### What it does
 
-`bin/install.js` copies 21 markdown files into `~/.claude/` (global) or `.claude/` (local), then writes MCP server config to `.mcp.json`. That's it — no runtime, no daemon.
+`bin/install.js` copies 28 markdown files into `~/.claude/` (global) or `.claude/` (local), then writes MCP server config to `.mcp.json`. That's it — no runtime, no daemon.
 
 ```
 npx video-research-mcp@latest
         │
-        ├── Copies 9 commands  → ~/.claude/commands/gr/
-        ├── Copies 7 skill files → ~/.claude/skills/
-        ├── Copies 4 agents    → ~/.claude/agents/
-        ├── Writes .mcp.json   → MCP server registration (3 servers)
+        ├── Copies 14 commands  → ~/.claude/commands/gr/ and commands/ve/
+        ├── Copies 8 skill files → ~/.claude/skills/
+        ├── Copies 6 agents    → ~/.claude/agents/
+        ├── Writes .mcp.json   → MCP server registration (5 servers)
         └── Writes manifest    → for upgrades/uninstall
 ```
 
@@ -46,31 +46,41 @@ Every file distributed by the plugin must be listed in `bin/lib/copy.js`:
 
 ```js
 const FILE_MAP = {
-  // Commands → /gr:* slash commands
-  'commands/video.md':      'commands/gr/video.md',
-  'commands/video-chat.md': 'commands/gr/video-chat.md',
-  'commands/research.md':   'commands/gr/research.md',
-  'commands/analyze.md':    'commands/gr/analyze.md',
-  'commands/search.md':     'commands/gr/search.md',
-  'commands/recall.md':     'commands/gr/recall.md',
-  'commands/models.md':     'commands/gr/models.md',
-  'commands/doctor.md':     'commands/gr/doctor.md',
-  'commands/traces.md':     'commands/gr/traces.md',
+  // Commands → /gr:* slash commands (11)
+  'commands/video.md':        'commands/gr/video.md',
+  'commands/video-chat.md':   'commands/gr/video-chat.md',
+  'commands/research.md':     'commands/gr/research.md',
+  'commands/analyze.md':      'commands/gr/analyze.md',
+  'commands/search.md':       'commands/gr/search.md',
+  'commands/recall.md':       'commands/gr/recall.md',
+  'commands/models.md':       'commands/gr/models.md',
+  'commands/doctor.md':       'commands/gr/doctor.md',
+  'commands/traces.md':       'commands/gr/traces.md',
+  'commands/research-doc.md': 'commands/gr/research-doc.md',
+  'commands/ingest.md':       'commands/gr/ingest.md',
 
-  // Skills → context injection
+  // Commands → /ve:* slash commands (3)
+  'commands/explainer.md':      'commands/ve/explainer.md',
+  'commands/explain-video.md':  'commands/ve/explain-video.md',
+  'commands/explain-status.md': 'commands/ve/explain-status.md',
+
+  // Skills → context injection (8 files across 5 skills)
   'skills/video-research/SKILL.md':                              'skills/video-research/SKILL.md',
   'skills/gemini-visualize/SKILL.md':                             'skills/gemini-visualize/SKILL.md',
   'skills/gemini-visualize/templates/video-concept-map.md':       'skills/gemini-visualize/templates/video-concept-map.md',
   'skills/gemini-visualize/templates/research-evidence-net.md':   'skills/gemini-visualize/templates/research-evidence-net.md',
   'skills/gemini-visualize/templates/content-knowledge-graph.md': 'skills/gemini-visualize/templates/content-knowledge-graph.md',
+  'skills/video-explainer/SKILL.md':                             'skills/video-explainer/SKILL.md',
   'skills/weaviate-setup/SKILL.md':                               'skills/weaviate-setup/SKILL.md',
   'skills/mlflow-traces/SKILL.md':                                'skills/mlflow-traces/SKILL.md',
 
-  // Agents → sub-agents
-  'agents/researcher.md':      'agents/researcher.md',
-  'agents/video-analyst.md':   'agents/video-analyst.md',
-  'agents/visualizer.md':      'agents/visualizer.md',
-  'agents/comment-analyst.md': 'agents/comment-analyst.md',
+  // Agents → sub-agents (6)
+  'agents/researcher.md':       'agents/researcher.md',
+  'agents/video-analyst.md':    'agents/video-analyst.md',
+  'agents/visualizer.md':       'agents/visualizer.md',
+  'agents/comment-analyst.md':  'agents/comment-analyst.md',
+  'agents/video-producer.md':   'agents/video-producer.md',
+  'agents/content-to-video.md': 'agents/content-to-video.md',
 };
 ```
 
@@ -87,7 +97,7 @@ The installer writes `~/.claude/gr-file-manifest.json` containing SHA-256 hashes
 
 ### MCP config merge
 
-`bin/lib/config.js` writes three MCP server entries to `.mcp.json`:
+`bin/lib/config.js` writes five MCP server entries to `.mcp.json`:
 
 ```json
 {
@@ -98,7 +108,7 @@ The installer writes `~/.claude/gr-file-manifest.json` containing SHA-256 hashes
     },
     "playwright": {
       "command": "npx",
-      "args": ["@playwright/mcp@latest", "--headless", "--caps=vision,pdf"]
+      "args": ["@playwright/mcp@0.0.68", "--headless", "--caps=vision,pdf"]
     },
     "mlflow-mcp": {
       "command": "uvx",
@@ -117,7 +127,7 @@ Config location: `~/.claude/.mcp.json` (global) or `./.mcp.json` (local, project
 
 The Python package (defined in `pyproject.toml`) is the actual MCP server. Users never install it manually — `uvx` handles it when Claude Code reads `.mcp.json`.
 
-The server exposes 23 tools across 7 sub-servers. See the Architecture section in the root `CLAUDE.md`.
+The server exposes 24 tools across 7 sub-servers. See the Architecture section in the root `CLAUDE.md`.
 
 ---
 
@@ -211,7 +221,7 @@ These run as background or foreground processes with their own tool restrictions
 
 ## Current Plugin Inventory
 
-### Commands (9)
+### Commands (14)
 
 | File | Slash Command | Tools | Model |
 |------|---------------|-------|-------|
@@ -224,17 +234,23 @@ These run as background or foreground processes with their own tool restrictions
 | `commands/models.md` | `/gr:models` | infra_configure | haiku |
 | `commands/traces.md` | `/gr:traces` | mlflow-mcp search_traces, get_trace, set_trace_tag, log_feedback, evaluate_traces | sonnet |
 | `commands/doctor.md` | `/gr:doctor` (`quick` compact, `full` detailed) | infra_configure, video_metadata, knowledge_stats, mlflow-mcp search_traces, Read/Glob/Bash | haiku |
+| `commands/research-doc.md` | `/gr:research-doc` | research_document, content_batch_analyze, Write/Glob/Read/Bash | sonnet |
+| `commands/ingest.md` | `/gr:ingest` | knowledge_ingest, knowledge_stats, knowledge_search, Read | sonnet |
+| `commands/explainer.md` | `/ve:explainer` | All 15 explainer tools, Read/Write/Glob | sonnet |
+| `commands/explain-video.md` | `/ve:explain-video` | video_analyze, research_deep, content_analyze, web_search + explainer tools | sonnet |
+| `commands/explain-status.md` | `/ve:explain-status` | explainer_status, explainer_list | haiku |
 
-### Skills (4)
+### Skills (5)
 
 | Skill | Purpose |
 |-------|---------|
-| `video-research` | Tool signatures, workflows, caching for 23 tools |
+| `video-research` | Tool signatures, workflows, caching for 24 tools |
 | `gemini-visualize` | HTML visualization generation + 3 templates |
+| `video-explainer` | Tool signatures and workflows for 15 explainer tools |
 | `weaviate-setup` | Interactive onboarding wizard for Weaviate connection |
 | `mlflow-traces` | MLflow trace debugging, field paths, `extract_fields` discipline |
 
-### Agents (4)
+### Agents (6)
 
 | Agent | Model | Purpose |
 |-------|-------|---------|
@@ -242,6 +258,8 @@ These run as background or foreground processes with their own tool restrictions
 | `video-analyst` | sonnet | Video analysis and Q&A sessions |
 | `visualizer` | sonnet | Background HTML visualization + screenshot |
 | `comment-analyst` | haiku | Background YouTube comment analysis |
+| `video-producer` | sonnet | Full pipeline orchestrator for explainer videos |
+| `content-to-video` | sonnet | Bridge agent — research analysis to explainer video |
 
 ---
 
@@ -253,7 +271,7 @@ USER: npx video-research-mcp@latest
          ▼
     bin/install.js (Node.js)
          │
-         ├── Copy 21 markdown files to ~/.claude/
+         ├── Copy 28 markdown files to ~/.claude/
          ├── Write .mcp.json (register MCP servers)
          └── Write manifest (for future upgrades)
 

--- a/docs/tutorials/GETTING_STARTED.md
+++ b/docs/tutorials/GETTING_STARTED.md
@@ -133,7 +133,7 @@ Add the server to your MCP configuration. For global access across all projects,
 
 For project-local configuration, create `.mcp.json` in the project root with the same structure.
 
-After saving, restart Claude Code. All 23 tools will appear automatically in Claude's tool list.
+After saving, restart Claude Code. All 24 tools will appear automatically in Claude's tool list.
 
 ## First Tool Calls
 

--- a/src/video_research_mcp/config.py
+++ b/src/video_research_mcp/config.py
@@ -118,6 +118,7 @@ class ServerConfig(BaseModel):
     tracing_enabled: bool = Field(default=False)
     mlflow_tracking_uri: str = Field(default="")
     mlflow_experiment_name: str = Field(default="video-research-mcp")
+    doc_max_download_bytes: int = Field(default=50 * 1024 * 1024)
 
     @field_validator("default_thinking_level")
     @classmethod
@@ -191,6 +192,7 @@ class ServerConfig(BaseModel):
             ),
             mlflow_tracking_uri=os.getenv("MLFLOW_TRACKING_URI", ""),
             mlflow_experiment_name=os.getenv("MLFLOW_EXPERIMENT_NAME", "video-research-mcp"),
+            doc_max_download_bytes=int(os.getenv("DOC_MAX_DOWNLOAD_BYTES", str(50 * 1024 * 1024))),
         )
 
 

--- a/src/video_research_mcp/errors.py
+++ b/src/video_research_mcp/errors.py
@@ -28,6 +28,7 @@ class ErrorCategory(str, Enum):
     WEAVIATE_QUERY = "WEAVIATE_QUERY"
     WEAVIATE_IMPORT = "WEAVIATE_IMPORT"
     DEPENDENCY_MISSING = "DEPENDENCY_MISSING"
+    URL_POLICY_BLOCKED = "URL_POLICY_BLOCKED"
     QUALITY_GATE_FAILED = "QUALITY_GATE_FAILED"
     ARTIFACT_GENERATION_FAILED = "ARTIFACT_GENERATION_FAILED"
     SCHEMA_VALIDATION_FAILED = "SCHEMA_VALIDATION_FAILED"
@@ -46,6 +47,11 @@ class ToolError(BaseModel):
 
 def categorize_error(error: Exception) -> tuple[ErrorCategory, str]:
     """Map an exception to an ErrorCategory + human-readable hint."""
+    from .url_policy import UrlPolicyError
+
+    if isinstance(error, UrlPolicyError):
+        return (ErrorCategory.URL_POLICY_BLOCKED, str(error))
+
     s = str(error).lower()
 
     if "403" in s and "permission" in s:

--- a/src/video_research_mcp/url_policy.py
+++ b/src/video_research_mcp/url_policy.py
@@ -1,0 +1,99 @@
+"""URL validation and safe download with SSRF protection.
+
+Enforces HTTPS-only, blocks private/loopback/link-local IP ranges,
+rejects embedded credentials, and streams downloads with a size cap.
+Used by research_document to safely fetch user-supplied URLs.
+"""
+
+from __future__ import annotations
+
+import logging
+import socket
+from ipaddress import ip_address
+from pathlib import Path
+from urllib.parse import urlparse
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class UrlPolicyError(Exception):
+    """Raised when a URL violates the security policy."""
+
+
+def validate_url(url: str) -> None:
+    """Validate a URL against the security policy.
+
+    Checks:
+    - HTTPS scheme only
+    - No embedded credentials (userinfo)
+    - Hostname present and DNS-resolvable
+    - Resolved IPs are not private, loopback, link-local, multicast, or reserved
+
+    Raises:
+        UrlPolicyError: If any check fails.
+    """
+    parsed = urlparse(url)
+
+    if parsed.scheme != "https":
+        raise UrlPolicyError(f"Only HTTPS URLs are allowed, got '{parsed.scheme}://'")
+
+    if parsed.username or parsed.password:
+        raise UrlPolicyError("URLs with embedded credentials are not allowed")
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise UrlPolicyError("URL has no hostname")
+
+    try:
+        addr_infos = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise UrlPolicyError(f"DNS resolution failed for '{hostname}': {exc}") from exc
+
+    for family, _type, _proto, _canonname, sockaddr in addr_infos:
+        ip_str = sockaddr[0]
+        ip = ip_address(ip_str)
+        if ip.is_loopback or ip.is_private or ip.is_link_local or ip.is_multicast or ip.is_reserved:
+            raise UrlPolicyError(
+                f"URL resolves to blocked IP range ({ip_str}) — "
+                "private, loopback, link-local, multicast, and reserved addresses are not allowed"
+            )
+
+
+async def download_checked(url: str, tmp_dir: Path, *, max_bytes: int) -> Path:
+    """Download a URL with SSRF protection and size limits.
+
+    Args:
+        url: HTTPS URL to download.
+        tmp_dir: Directory to write the downloaded file into.
+        max_bytes: Maximum response body size in bytes.
+
+    Returns:
+        Path to the downloaded file.
+
+    Raises:
+        UrlPolicyError: If the URL fails validation or the response exceeds max_bytes.
+        httpx.HTTPStatusError: If the server returns an error status.
+    """
+    validate_url(url)
+
+    url_path = url.rsplit("/", 1)[-1].split("?")[0]
+    filename = url_path if "." in url_path else "document.pdf"
+    local = tmp_dir / filename
+
+    async with httpx.AsyncClient(follow_redirects=False, timeout=60) as client:
+        async with client.stream("GET", url) as resp:
+            resp.raise_for_status()
+            accumulated = 0
+            with local.open("wb") as f:
+                async for chunk in resp.aiter_bytes():
+                    accumulated += len(chunk)
+                    if accumulated > max_bytes:
+                        raise UrlPolicyError(
+                            f"Response exceeds size limit ({max_bytes} bytes)"
+                        )
+                    f.write(chunk)
+
+    logger.info("Downloaded %s (%d bytes) to %s", url, accumulated, local)
+    return local

--- a/tests/test_url_policy.py
+++ b/tests/test_url_policy.py
@@ -1,0 +1,204 @@
+"""Tests for URL policy validation and safe download."""
+
+from __future__ import annotations
+
+import socket
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from video_research_mcp.url_policy import UrlPolicyError, download_checked, validate_url
+
+
+def _mock_getaddrinfo(ip: str):
+    """Return a mock getaddrinfo result resolving to the given IP."""
+    return [(2, 1, 6, "", (ip, 0))]
+
+
+class _AsyncIterBytes:
+    """Async iterator that yields chunks of bytes."""
+
+    def __init__(self, chunks: list[bytes]):
+        self._chunks = iter(chunks)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._chunks)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+class _FakeResponse:
+    """Minimal httpx response mock with async streaming."""
+
+    def __init__(self, chunks: list[bytes]):
+        self._chunks = chunks
+
+    def raise_for_status(self):
+        pass
+
+    def aiter_bytes(self):
+        return _AsyncIterBytes(self._chunks)
+
+
+class _FakeStreamCtx:
+    """Async context manager wrapping a FakeResponse."""
+
+    def __init__(self, resp: _FakeResponse):
+        self._resp = resp
+
+    async def __aenter__(self):
+        return self._resp
+
+    async def __aexit__(self, *args):
+        pass
+
+
+class _FakeClient:
+    """Minimal httpx.AsyncClient mock."""
+
+    def __init__(self, resp: _FakeResponse):
+        self._resp = resp
+
+    def stream(self, method, url):
+        return _FakeStreamCtx(self._resp)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+
+class TestValidateUrl:
+    """Tests for validate_url()."""
+
+    def test_rejects_http(self):
+        """HTTP scheme is blocked — only HTTPS allowed."""
+        with pytest.raises(UrlPolicyError, match="Only HTTPS"):
+            validate_url("http://example.com/doc.pdf")
+
+    def test_rejects_ftp(self):
+        """FTP scheme is blocked."""
+        with pytest.raises(UrlPolicyError, match="Only HTTPS"):
+            validate_url("ftp://example.com/doc.pdf")
+
+    @patch("video_research_mcp.url_policy.socket.getaddrinfo", return_value=_mock_getaddrinfo("93.184.216.34"))
+    def test_accepts_https(self, _mock_dns):
+        """HTTPS with a public IP passes."""
+        validate_url("https://example.com/doc.pdf")
+
+    def test_rejects_credentials(self):
+        """URLs with embedded user:pass are blocked."""
+        with pytest.raises(UrlPolicyError, match="embedded credentials"):
+            validate_url("https://user:pass@example.com/doc.pdf")
+
+    def test_rejects_username_only(self):
+        """URLs with embedded username (no password) are blocked."""
+        with pytest.raises(UrlPolicyError, match="embedded credentials"):
+            validate_url("https://user@example.com/doc.pdf")
+
+    def test_rejects_no_hostname(self):
+        """URLs without a hostname are blocked."""
+        with pytest.raises(UrlPolicyError, match="no hostname"):
+            validate_url("https:///path/to/doc.pdf")
+
+    @patch("video_research_mcp.url_policy.socket.getaddrinfo", return_value=_mock_getaddrinfo("192.168.1.1"))
+    def test_rejects_private_ip(self, _mock_dns):
+        """Private IPs (192.168.x.x) are blocked."""
+        with pytest.raises(UrlPolicyError, match="blocked IP range"):
+            validate_url("https://internal.corp/doc.pdf")
+
+    @patch("video_research_mcp.url_policy.socket.getaddrinfo", return_value=_mock_getaddrinfo("10.0.0.1"))
+    def test_rejects_private_10_range(self, _mock_dns):
+        """Private IPs (10.x.x.x) are blocked."""
+        with pytest.raises(UrlPolicyError, match="blocked IP range"):
+            validate_url("https://internal.corp/doc.pdf")
+
+    @patch("video_research_mcp.url_policy.socket.getaddrinfo", return_value=_mock_getaddrinfo("127.0.0.1"))
+    def test_rejects_loopback(self, _mock_dns):
+        """Loopback (127.0.0.1) is blocked."""
+        with pytest.raises(UrlPolicyError, match="blocked IP range"):
+            validate_url("https://localhost/doc.pdf")
+
+    @patch("video_research_mcp.url_policy.socket.getaddrinfo", return_value=_mock_getaddrinfo("169.254.169.254"))
+    def test_rejects_link_local(self, _mock_dns):
+        """Link-local (169.254.x.x, cloud metadata) is blocked."""
+        with pytest.raises(UrlPolicyError, match="blocked IP range"):
+            validate_url("https://metadata.google.internal/doc.pdf")
+
+    @patch("video_research_mcp.url_policy.socket.getaddrinfo", side_effect=socket.gaierror("Name resolution failed"))
+    def test_rejects_dns_failure(self, _mock_dns):
+        """DNS resolution failure is blocked."""
+        with pytest.raises(UrlPolicyError, match="DNS resolution failed"):
+            validate_url("https://nonexistent.example.invalid/doc.pdf")
+
+
+class TestDownloadChecked:
+    """Tests for download_checked()."""
+
+    async def test_enforces_size_limit(self, tmp_path: Path):
+        """Downloads exceeding max_bytes raise UrlPolicyError."""
+        large_chunk = b"x" * 1000
+        resp = _FakeResponse([large_chunk, large_chunk])
+        client = _FakeClient(resp)
+
+        with (
+            patch("video_research_mcp.url_policy.validate_url"),
+            patch("video_research_mcp.url_policy.httpx.AsyncClient", return_value=client),
+        ):
+            with pytest.raises(UrlPolicyError, match="exceeds size limit"):
+                await download_checked(
+                    "https://example.com/huge.pdf", tmp_path, max_bytes=500
+                )
+
+    async def test_no_redirects(self, tmp_path: Path):
+        """Client is created with follow_redirects=False."""
+        resp = _FakeResponse([b"content"])
+        client = _FakeClient(resp)
+        mock_cls = MagicMock(return_value=client)
+
+        with (
+            patch("video_research_mcp.url_policy.validate_url"),
+            patch("video_research_mcp.url_policy.httpx.AsyncClient", mock_cls),
+        ):
+            await download_checked(
+                "https://example.com/doc.pdf", tmp_path, max_bytes=10_000
+            )
+            mock_cls.assert_called_once_with(follow_redirects=False, timeout=60)
+
+    async def test_writes_file(self, tmp_path: Path):
+        """Happy path: file is written to tmp_dir."""
+        content = b"PDF content here"
+        resp = _FakeResponse([content])
+        client = _FakeClient(resp)
+
+        with (
+            patch("video_research_mcp.url_policy.validate_url"),
+            patch("video_research_mcp.url_policy.httpx.AsyncClient", return_value=client),
+        ):
+            result = await download_checked(
+                "https://example.com/report.pdf", tmp_path, max_bytes=10_000
+            )
+
+        assert result == tmp_path / "report.pdf"
+        assert result.read_bytes() == content
+
+    async def test_fallback_filename(self, tmp_path: Path):
+        """URLs without a file extension use document.pdf as filename."""
+        resp = _FakeResponse([b"data"])
+        client = _FakeClient(resp)
+
+        with (
+            patch("video_research_mcp.url_policy.validate_url"),
+            patch("video_research_mcp.url_policy.httpx.AsyncClient", return_value=client),
+        ):
+            result = await download_checked(
+                "https://example.com/download", tmp_path, max_bytes=10_000
+            )
+
+        assert result.name == "document.pdf"

--- a/uv.lock
+++ b/uv.lock
@@ -1703,6 +1703,7 @@ dependencies = [
     { name = "fastmcp" },
     { name = "google-api-python-client" },
     { name = "google-genai" },
+    { name = "httpx" },
     { name = "pydantic" },
     { name = "weaviate-client" },
 ]
@@ -1712,10 +1713,14 @@ agents = [
     { name = "weaviate-agents" },
 ]
 dev = [
+    { name = "jsonschema" },
     { name = "mlflow-tracing" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
+]
+strict = [
+    { name = "jsonschema" },
 ]
 tracing = [
     { name = "mlflow-tracing" },
@@ -1726,6 +1731,9 @@ requires-dist = [
     { name = "fastmcp", specifier = ">=3.0.2" },
     { name = "google-api-python-client", specifier = ">=2.100" },
     { name = "google-genai", specifier = ">=1.57" },
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.0" },
+    { name = "jsonschema", marker = "extra == 'strict'", specifier = ">=4.0" },
     { name = "mlflow-tracing", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "mlflow-tracing", marker = "extra == 'tracing'", specifier = ">=3.0" },
     { name = "pydantic", specifier = ">=2.0" },
@@ -1735,7 +1743,7 @@ requires-dist = [
     { name = "weaviate-agents", marker = "extra == 'agents'", specifier = ">=1.2.0" },
     { name = "weaviate-client", specifier = ">=4.19.2" },
 ]
-provides-extras = ["tracing", "agents", "dev"]
+provides-extras = ["tracing", "agents", "strict", "dev"]
 
 [[package]]
 name = "watchfiles"


### PR DESCRIPTION
## Summary

Addresses 5 of 6 findings from the [plugin readiness audit](code-reviews/plugin-readiness-audit-2026-03-01.md):

- **F-01 (P1 Security)**: SSRF hardening in `research_document` URL fetch — new `url_policy.py` with HTTPS-only, DNS pre-resolution blocking private/loopback/link-local IPs, no redirect following, streaming size cap (`DOC_MAX_DOWNLOAD_BYTES` env var, 50 MB default). 15 new unit tests.
- **F-02 (P1 Usability)**: Fix parameter mismatches in `explain-video.md` — `content_analyze(source=)` → `url=`, `research_deep(instruction=)` → topic string IS the instruction.
- **F-03 (P2 UX)**: Sync doc inventory with code — tools 23→24, commands 9→14, skills 4→5, agents 4→6, FILE_MAP 21→28 entries.
- **F-04 (P2 Supply Chain)**: Pin `@playwright/mcp@latest` → `@0.0.68` in config and docs.
- **F-05 (XS)**: Add `mlflow.db` and `video_analysis/` to `.gitignore`.

F-06 (P3, security docs) deferred — low confidence, env var from F-01 provides configurability.

## Test plan

- [x] 621 tests pass (15 new + 606 existing)
- [x] `ruff check src/ tests/` clean
- [x] Tool count gate: 24 tools confirmed
- [x] `node bin/install.js --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)