### PR TITLE
feat: add Ollama vectorizer support for local embeddings

### DIFF
--- a/src/video_research_mcp/config.py
+++ b/src/video_research_mcp/config.py
@@ -174,8 +174,8 @@ class ServerConfig(BaseModel):
     @classmethod
     def validate_weaviate_vectorizer(cls, value: str) -> str:
         v = value.strip().lower()
-        if v not in ("openai", "weaviate"):
-            raise ValueError(f"WEAVIATE_VECTORIZER must be 'openai' or 'weaviate', got '{value}'")
+        if v not in ("openai", "weaviate", "ollama"):
+            raise ValueError(f"WEAVIATE_VECTORIZER must be 'openai', 'weaviate', or 'ollama', got '{value}'")
         return v
 
     @field_validator("deep_research_agent")

--- a/src/video_research_mcp/weaviate_migrate.py
+++ b/src/video_research_mcp/weaviate_migrate.py
@@ -8,6 +8,8 @@ cloud-to-local migration, or vectorizer provider changes).
 
 from __future__ import annotations
 
+import os
+
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -36,6 +38,16 @@ def build_vector_config(col_def: CollectionDef) -> Any:
     source_props = col_def.vectorized_properties() or None
     if cfg.weaviate_vectorizer == "weaviate":
         return Configure.Vectors.text2vec_weaviate(source_properties=source_props)
+    if cfg.weaviate_vectorizer == "ollama":
+        api_endpoint = os.environ.get(
+            "WEAVIATE_OLLAMA_API_ENDPOINT", "http://host.docker.internal:11434"
+        )
+        model = os.environ.get("WEAVIATE_OLLAMA_MODEL", "nomic-embed-text")
+        return Configure.Vectors.text2vec_ollama(
+            source_properties=source_props,
+            api_endpoint=api_endpoint,
+            model=model,
+        )
     return Configure.Vectors.text2vec_openai(source_properties=source_props)
 
 
@@ -88,7 +100,8 @@ def _get_current_vectorizer_module(col_config: Any) -> str | None:
 def _desired_vectorizer_module() -> str:
     """Return the vectorizer module name matching current config."""
     cfg = get_config()
-    return "text2vec-weaviate" if cfg.weaviate_vectorizer == "weaviate" else "text2vec-openai"
+    mapping = {"weaviate": "text2vec-weaviate", "ollama": "text2vec-ollama"}
+    return mapping.get(cfg.weaviate_vectorizer, "text2vec-openai")
 
 
 def needs_vector_migration(col_config: Any, col_def: CollectionDef) -> bool:

--- a/src/video_research_mcp/weaviate_schema/base.py
+++ b/src/video_research_mcp/weaviate_schema/base.py
@@ -36,9 +36,10 @@ class PropertyDef:
         if self.description:
             result["description"] = self.description
         if self.skip_vectorization:
-            result["moduleConfig"] = {
-                "text2vec-openai": {"skip": True},
-            }
+            import os
+            _vz = os.getenv("WEAVIATE_VECTORIZER", "openai").strip().lower()
+            _module = {"weaviate": "text2vec-weaviate", "ollama": "text2vec-ollama"}.get(_vz, "text2vec-openai")
+            result["moduleConfig"] = {_module: {"skip": True}}
         return result
 
 


### PR DESCRIPTION
## Summary

- Adds `text2vec-ollama` as a third vectorizer option alongside `openai` and `weaviate`
- Allows users running Ollama locally (e.g. with `nomic-embed-text`) to use the Weaviate knowledge store without needing an OpenAI API key or Weaviate Cloud account
- Fixes `_desired_vectorizer_module()` which didn't handle non-openai/weaviate vectorizers, causing incorrect migration detection
- Makes `skip_vectorization` moduleConfig dynamic instead of hardcoded to `text2vec-openai`

## Motivation

Running Weaviate locally with Docker is straightforward, but the current vectorizer options require either a paid OpenAI API key or a Weaviate Cloud account. Ollama provides free, local embeddings (e.g. `nomic-embed-text` producing 768-dim vectors) that work great with Weaviate's `text2vec-ollama` module. This PR adds first-class support for that setup.

## Changes

| File | Change |
|------|--------|
| `config.py` | Accept `'ollama'` in `WEAVIATE_VECTORIZER` validator |
| `weaviate_migrate.py` | Add `text2vec_ollama` code path in `build_vector_config()`; fix `_desired_vectorizer_module()` to return `'text2vec-ollama'` |
| `weaviate_schema/base.py` | Make `skip_vectorization` moduleConfig dynamic (reads `WEAVIATE_VECTORIZER` env var) |

## New Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `WEAVIATE_OLLAMA_API_ENDPOINT` | `http://host.docker.internal:11434` | Ollama API endpoint (Docker-friendly default) |
| `WEAVIATE_OLLAMA_MODEL` | `nomic-embed-text` | Embedding model name |

## Testing

Tested locally with:
- Weaviate 1.28 in Docker + Ollama with `nomic-embed-text`
- `WEAVIATE_VECTORIZER=ollama`
- Verified: collection creation, object insertion (768-dim vectors), `nearText` semantic search (0.77 certainty)
- Migration detection works correctly (no false-positive triggers)