### PR TITLE
feat(video): windowed local-video analysis + large-upload robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Windowed analysis of local videos** — `video_analyze` now accepts `fps`, `start_offset`, and `end_offset` for local `file_path` videos, attaching `types.VideoMetadata` to the video part. A long recording that exceeds the single-pass context budget can be analyzed in time-window segments (e.g. four 27-minute windows) while keeping on-screen detail legible. Per-window results are cache-isolated via a window-aware cache key (`analyze_video(cache_discriminator=...)`), so re-running a window hits cache and different windows never collide. Window params are local-file-only and fail fast if combined with a YouTube URL.
 
+### Fixed
+
+- **Large local-video uploads no longer re-upload after a processing timeout** — the Gemini File API upload-cache entry is now written *before* waiting for the file to reach `ACTIVE`, and the active-wait window was raised to 600s (from 120s). Previously a multi-GB video whose server-side processing exceeded 120s raised a timeout *and* left no cache entry, forcing a full re-upload on every retry; now a retry reuses the already-uploaded file.
+
 ## [0.6.1] - 2026-05-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Windowed analysis of local videos** — `video_analyze` now accepts `fps`, `start_offset`, and `end_offset` for local `file_path` videos, attaching `types.VideoMetadata` to the video part. A long recording that exceeds the single-pass context budget can be analyzed in time-window segments (e.g. four 27-minute windows) while keeping on-screen detail legible. Per-window results are cache-isolated via a window-aware cache key (`analyze_video(cache_discriminator=...)`), so re-running a window hits cache and different windows never collide. Window params are local-file-only and fail fast if combined with a YouTube URL.
+
 ## [0.6.1] - 2026-05-21
 
 ### Changed

--- a/src/video_research_mcp/tools/video.py
+++ b/src/video_research_mcp/tools/video.py
@@ -125,6 +125,21 @@ async def video_analyze(
     )] = None,
     thinking_level: ThinkingLevel = "high",
     use_cache: Annotated[bool, Field(description="Use cached results")] = True,
+    fps: Annotated[float | None, Field(
+        gt=0,
+        description="Local files only: frames per second to sample. Lower = "
+        "faster/cheaper, higher = captures more on-screen detail. "
+        "Default lets Gemini choose."
+    )] = None,
+    start_offset: Annotated[str | None, Field(
+        description="Local files only: start of the analysis window, e.g. '0s', "
+        "'27m'. Pair with end_offset to analyze a long video in segments that "
+        "each fit the context budget."
+    )] = None,
+    end_offset: Annotated[str | None, Field(
+        description="Local files only: end of the analysis window, e.g. '27m', "
+        "'1640s'."
+    )] = None,
     strict_contract: Annotated[bool, Field(
         description="Enable strict contract pipeline with quality gates, "
         "artifact rendering, and semantic validation. Produces richer output "
@@ -141,6 +156,11 @@ async def video_analyze(
     strict Pydantic models, parallel strategy/concept-map generation, artifact
     rendering, and quality gates. Returns richer output but takes longer.
 
+    For a long local video that exceeds the context budget in a single pass,
+    analyze it in segments by calling repeatedly with ``start_offset``/
+    ``end_offset`` windows (and optionally a higher ``fps`` to capture more
+    on-screen detail), then synthesize the per-window results.
+
     Args:
         url: YouTube video URL.
         file_path: Path to a local video file.
@@ -148,6 +168,9 @@ async def video_analyze(
         output_schema: Optional JSON Schema dict for custom output shape.
         thinking_level: Gemini thinking depth.
         use_cache: Whether to use cached results.
+        fps: Local files only — frames per second to sample.
+        start_offset: Local files only — start of the analysis window.
+        end_offset: Local files only — end of the analysis window.
         strict_contract: Run strict contract pipeline with quality gates.
 
     Returns:
@@ -175,6 +198,14 @@ async def video_analyze(
     except ValueError as exc:
         return make_tool_error(exc)
 
+    has_window = fps is not None or start_offset is not None or end_offset is not None
+    if url is not None and has_window:
+        return make_tool_error(ValueError(
+            "fps/start_offset/end_offset apply to local files only (file_path), "
+            "not YouTube URLs."
+        ))
+    cache_discriminator = f"|win:{start_offset}-{end_offset}@{fps}" if has_window else ""
+
     try:
         metadata_context = None
         local_filepath = ""
@@ -195,7 +226,13 @@ async def video_analyze(
             else:
                 contents = _video_content(clean_url, instruction)
         else:
-            contents, content_id, file_uri = await _video_file_content(file_path, instruction)
+            contents, content_id, file_uri = await _video_file_content(
+                file_path,
+                instruction,
+                fps=fps,
+                start_offset=start_offset,
+                end_offset=end_offset,
+            )
             source_label = file_path
             local_filepath = str(Path(file_path).expanduser().resolve())
 
@@ -223,6 +260,7 @@ async def video_analyze(
             metadata_context=metadata_context,
             local_filepath=local_filepath,
             screenshot_dir=screenshot_dir,
+            cache_discriminator=cache_discriminator,
         )
         result["local_filepath"] = local_filepath
         result["screenshot_dir"] = screenshot_dir

--- a/src/video_research_mcp/tools/video_core.py
+++ b/src/video_research_mcp/tools/video_core.py
@@ -48,6 +48,7 @@ async def analyze_video(
     metadata_context: str | None = None,
     local_filepath: str = "",
     screenshot_dir: str = "",
+    cache_discriminator: str = "",
 ) -> dict:
     """Run the video analysis pipeline shared by video_analyze and video_batch_analyze.
 
@@ -62,14 +63,18 @@ async def analyze_video(
         metadata_context: Optional video metadata context to prepend to the prompt.
         local_filepath: Local filesystem path to the analyzed/downloaded video.
         screenshot_dir: Local filesystem path to extracted screenshots.
+        cache_discriminator: Extra cache-key salt (e.g. a time window). Two calls
+            with the same content_id and instruction but different windows must
+            pass distinct discriminators to avoid returning each other's result.
 
     Returns:
         Dict matching VideoResult schema (default) or the custom output_schema.
     """
     cfg = get_config()
 
+    cache_instruction = f"{instruction}{cache_discriminator}"
     if use_cache:
-        cached = cache_load(content_id, "video_analyze", cfg.default_model, instruction=instruction)
+        cached = cache_load(content_id, "video_analyze", cfg.default_model, instruction=cache_instruction)
         if cached:
             cached["cached"] = True
             return cached
@@ -104,7 +109,7 @@ async def analyze_video(
 
     result["source"] = source_label
     if use_cache:
-        cache_save(content_id, "video_analyze", cfg.default_model, result, instruction=instruction)
+        cache_save(content_id, "video_analyze", cfg.default_model, result, instruction=cache_instruction)
     from ..weaviate_store import store_video_analysis, extract_and_store_graph
     await store_video_analysis(
         result,

--- a/src/video_research_mcp/tools/video_file.py
+++ b/src/video_research_mcp/tools/video_file.py
@@ -167,11 +167,30 @@ async def _upload_large_file(path: Path, mime_type: str, content_hash: str = "")
         return uploaded.uri
 
 
-async def _video_file_content(file_path: str, prompt: str) -> tuple[types.Content, str, str]:
+async def _video_file_content(
+    file_path: str,
+    prompt: str,
+    *,
+    fps: float | None = None,
+    start_offset: str | None = None,
+    end_offset: str | None = None,
+) -> tuple[types.Content, str, str]:
     """Build Content for a local video file.
 
     Small files (<20 MB) use inline Part.from_bytes.
     Large files are uploaded via the File API.
+
+    When any of ``fps``/``start_offset``/``end_offset`` is set, a
+    ``types.VideoMetadata`` is attached to the video Part so Gemini samples
+    only the requested time window / frame rate. This enables windowed
+    analysis of long videos that would otherwise exceed the context budget.
+
+    Args:
+        file_path: Path to the local video file.
+        prompt: Text prompt for analysis.
+        fps: Frames per second to sample. Lower = faster, higher = more detail.
+        start_offset: Start of the analysis window (e.g. "0s", "27m").
+        end_offset: End of the analysis window (e.g. "27m", "1640s").
 
     Returns:
         (content, content_id, file_uri) where content_id is the SHA-256 hash
@@ -183,14 +202,20 @@ async def _video_file_content(file_path: str, prompt: str) -> tuple[types.Conten
 
     if size >= LARGE_FILE_THRESHOLD:
         file_uri = await _upload_large_file(p, mime, content_hash=content_id)
-        parts = [types.Part(file_data=types.FileData(file_uri=file_uri))]
+        video_part = types.Part(file_data=types.FileData(file_uri=file_uri))
     else:
         file_uri = ""
         data = await asyncio.to_thread(p.read_bytes)
-        parts = [types.Part.from_bytes(data=data, mime_type=mime)]
+        video_part = types.Part.from_bytes(data=data, mime_type=mime)
 
-    parts.append(types.Part(text=prompt))
-    return types.Content(parts=parts), content_id, file_uri
+    if fps is not None or start_offset is not None or end_offset is not None:
+        video_part.video_metadata = types.VideoMetadata(
+            fps=fps,
+            start_offset=start_offset,
+            end_offset=end_offset,
+        )
+
+    return types.Content(parts=[video_part, types.Part(text=prompt)]), content_id, file_uri
 
 
 async def _video_file_uri(file_path: str) -> tuple[str, str]:

--- a/src/video_research_mcp/tools/video_file.py
+++ b/src/video_research_mcp/tools/video_file.py
@@ -29,6 +29,12 @@ SUPPORTED_VIDEO_EXTENSIONS: dict[str, str] = {
 }
 
 LARGE_FILE_THRESHOLD = 20 * 1024 * 1024  # 20 MB
+# Gemini File API: large videos can need several minutes of server-side
+# processing before reaching ACTIVE. Wait generously, and persist the
+# upload-cache entry BEFORE waiting (see _upload_large_file) so a client-side
+# timeout never forces a re-upload of a multi-GB file.
+_UPLOAD_ACTIVE_TIMEOUT = 600.0
+_CACHE_REVALIDATE_TIMEOUT = 120.0
 _UPLOAD_LOCKS: dict[str, asyncio.Lock] = {}
 _UPLOAD_LOCKS_GUARD = asyncio.Lock()
 
@@ -131,7 +137,8 @@ async def _upload_large_file(path: Path, mime_type: str, content_hash: str = "")
 
     When ``content_hash`` is provided, checks an on-disk cache first. If the
     cached file is still ACTIVE on the server, the upload is skipped entirely.
-    This prevents re-upload loops when MCP clients retry after a timeout.
+    The cache entry is written BEFORE waiting for ACTIVE, so a wait timeout on a
+    multi-GB upload never forces a re-upload — a retry reuses the uploaded file.
     """
     client = GeminiClient.get()
 
@@ -141,7 +148,7 @@ async def _upload_large_file(path: Path, mime_type: str, content_hash: str = "")
             config=types.UploadFileConfig(mime_type=mime_type),
         )
         logger.info("Uploaded %s → %s (state=%s)", path.name, uploaded.uri, uploaded.state)
-        await _wait_for_active(client, uploaded.name)
+        await _wait_for_active(client, uploaded.name, timeout=_UPLOAD_ACTIVE_TIMEOUT)
         return uploaded.uri
 
     async with _UPLOAD_LOCKS_GUARD:
@@ -151,7 +158,9 @@ async def _upload_large_file(path: Path, mime_type: str, content_hash: str = "")
         cached = _load_upload_cache(content_hash)
         if cached:
             try:
-                await _wait_for_active(client, cached["file_name"], timeout=10)
+                await _wait_for_active(
+                    client, cached["file_name"], timeout=_CACHE_REVALIDATE_TIMEOUT
+                )
                 logger.info("Upload cache hit for %s → %s", path.name, cached["file_uri"])
                 return cached["file_uri"]
             except (RuntimeError, TimeoutError, KeyError):
@@ -162,8 +171,10 @@ async def _upload_large_file(path: Path, mime_type: str, content_hash: str = "")
             config=types.UploadFileConfig(mime_type=mime_type),
         )
         logger.info("Uploaded %s → %s (state=%s)", path.name, uploaded.uri, uploaded.state)
-        await _wait_for_active(client, uploaded.name)
+        # Persist the cache entry BEFORE waiting for ACTIVE: a multi-GB upload
+        # that times out here must not be repeated — a retry reuses this file.
         _save_upload_cache(content_hash, uploaded.uri, uploaded.name)
+        await _wait_for_active(client, uploaded.name, timeout=_UPLOAD_ACTIVE_TIMEOUT)
         return uploaded.uri
 
 

--- a/tests/test_video_core.py
+++ b/tests/test_video_core.py
@@ -119,6 +119,42 @@ class TestAnalyzeVideo:
         assert call_kwargs["local_filepath"] == "/tmp/video.mp4"
         assert call_kwargs["screenshot_dir"] == "/tmp/screens/vid123"
 
+    @pytest.mark.asyncio
+    async def test_cache_discriminator_prevents_window_collision(
+        self, mock_gemini_client, tmp_path, monkeypatch
+    ):
+        """Same content_id+instruction but different windows must not share a cache entry."""
+        from video_research_mcp import cache
+        from video_research_mcp.config import ServerConfig
+
+        monkeypatch.setattr(cache, "_cache_dir", lambda: tmp_path)
+        # Seed a cache entry for window A only.
+        cache.save(
+            "disc_id", "video_analyze", "test-model",
+            {"title": "Window A"},
+            instruction="test|win:0s-27m@1.0",
+        )
+        mock_gemini_client["generate_structured"].return_value = VideoResult(title="Window B")
+        cfg = ServerConfig(gemini_api_key="test-key-not-real", default_model="test-model")
+
+        with patch("video_research_mcp.tools.video_core.get_config", return_value=cfg):
+            hit = await analyze_video(
+                _make_video_content(), instruction="test", content_id="disc_id",
+                source_label="src", use_cache=True,
+                cache_discriminator="|win:0s-27m@1.0",
+            )
+            miss = await analyze_video(
+                _make_video_content(), instruction="test", content_id="disc_id",
+                source_label="src", use_cache=True,
+                cache_discriminator="|win:27m-54m@1.0",
+            )
+
+        assert hit["title"] == "Window A"
+        assert hit["cached"] is True
+        # Different window → cache miss → fresh Gemini call returns Window B.
+        assert miss["title"] == "Window B"
+        mock_gemini_client["generate_structured"].assert_called_once()
+
 
 class TestEnrichPrompt:
     def test_replaces_text_part(self):

--- a/tests/test_video_file.py
+++ b/tests/test_video_file.py
@@ -375,3 +375,26 @@ class TestUploadCache:
 
         assert results == ["https://api.example/files/one", "https://api.example/files/one"]
         mock_gemini_client["client"].aio.files.upload.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cache_saved_before_active_wait(self, tmp_path, mock_gemini_client, monkeypatch):
+        """Cache persists even if the file never reaches ACTIVE, so a retry reuses the upload."""
+        f = tmp_path / "big.mp4"
+        f.write_bytes(b"\x00" * 100)
+        uploaded = _mock_upload_result(uri="https://api.example/files/slow", name="files/slow")
+        mock_gemini_client["client"].aio.files.upload = AsyncMock(return_value=uploaded)
+
+        async def _never_active(*_args, **_kwargs):
+            raise TimeoutError("not active")
+
+        monkeypatch.setattr(
+            "video_research_mcp.tools.video_file._wait_for_active", _never_active
+        )
+
+        with pytest.raises(TimeoutError):
+            await _upload_large_file(f, "video/mp4", content_hash="slow_hash")
+
+        # Cache was written before the (failed) wait → retry reuses the upload.
+        cache_file = self.cache_dir / "slow_hash.json"
+        assert cache_file.exists()
+        assert json.loads(cache_file.read_text())["file_name"] == "files/slow"

--- a/tests/test_video_file.py
+++ b/tests/test_video_file.py
@@ -142,6 +142,54 @@ class TestVideoFileContent:
         with pytest.raises(FileNotFoundError):
             await _video_file_content("/nonexistent/video.mp4", "test")
 
+    @pytest.mark.asyncio
+    async def test_window_metadata_on_small_inline(self, tmp_path, mock_gemini_client):
+        """fps/start/end attach VideoMetadata to an inline (small-file) video part."""
+        f = tmp_path / "small.mp4"
+        f.write_bytes(b"\x00" * 100)
+
+        content, _, _ = await _video_file_content(
+            str(f), "analyze", fps=1.0, start_offset="0s", end_offset="27m",
+        )
+
+        vm = content.parts[0].video_metadata
+        assert vm is not None
+        assert vm.fps == 1.0
+        assert vm.start_offset == "0s"
+        assert vm.end_offset == "27m"
+
+    @pytest.mark.asyncio
+    async def test_window_metadata_on_large_upload(self, tmp_path, mock_gemini_client):
+        """fps/start/end attach VideoMetadata to an uploaded (large-file) video part."""
+        f = tmp_path / "big.mp4"
+        f.write_bytes(b"\x00" * LARGE_FILE_THRESHOLD)
+        uploaded = _mock_upload_result()
+        mock_gemini_client["client"].aio.files.upload = AsyncMock(return_value=uploaded)
+        mock_gemini_client["client"].aio.files.get = AsyncMock(
+            return_value=MagicMock(state="ACTIVE")
+        )
+
+        content, _, file_uri = await _video_file_content(
+            str(f), "analyze", start_offset="27m", end_offset="54m",
+        )
+
+        assert content.parts[0].file_data.file_uri == uploaded.uri
+        assert file_uri == uploaded.uri
+        vm = content.parts[0].video_metadata
+        assert vm is not None
+        assert vm.start_offset == "27m"
+        assert vm.end_offset == "54m"
+
+    @pytest.mark.asyncio
+    async def test_no_window_leaves_metadata_unset(self, tmp_path, mock_gemini_client):
+        """Without window params the video part carries no VideoMetadata (unchanged)."""
+        f = tmp_path / "small.mp4"
+        f.write_bytes(b"\x00" * 100)
+
+        content, _, _ = await _video_file_content(str(f), "summarize")
+
+        assert content.parts[0].video_metadata is None
+
 
 class TestVideoFileUri:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Two additive, backward-compatible changes that make `video_analyze` usable on **long local videos** (validated on a 1h49m / 1.5 GB meeting recording).

### 1. Windowed local-video analysis (`e326fde`)
- `video_analyze` now accepts `fps`, `start_offset`, `end_offset` for local `file_path` videos, attaching `types.VideoMetadata` to the video part — mirrors the existing YouTube `_video_content_with_metadata` helper.
- Lets a recording that exceeds the single-pass context budget be analyzed in **time-window segments** while keeping on-screen detail legible.
- Per-window cache isolation via `analyze_video(cache_discriminator=...)`: re-running a window hits cache, different windows never collide.
- **Local-file-only**; fails fast if combined with a YouTube URL, so the tuned YouTube metadata pipeline is untouched.

### 2. Large-upload robustness (`bd980e8`)
- The Gemini File API upload-cache entry is now written **before** waiting for `ACTIVE`, and the active-wait window was raised 120s → 600s.
- Previously a multi-GB video whose server-side processing exceeded 120s timed out **and** left no cache entry → full re-upload on every retry. Now a retry reuses the already-uploaded file.

## Tests
- 4 new unit tests: metadata attachment (inline + upload paths), cache-key window discrimination, cache-saved-before-active-wait.
- 162 video tests pass, `ruff` clean. CHANGELOG updated under `[Unreleased]`.

## Real-world validation
Used to process a 1h49m local Tekla meeting recording into a full Dutch transcript + screen-demonstration log (11 × 10-min windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)